### PR TITLE
fix: add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./index.cjs",
       "import": "./index.mjs"
     }


### PR DESCRIPTION
### Description

In one of my projects, I have noticed that when importing your package, I get warning info from TypeScript _(from the LSP -`tsserver` - to be more specific)_ that it cannot find the types, even though they exist in your repository in [./index.d.ts](./index.d.ts).

> **Warning**:
> Could not find a declaration file for module 'local-pkg'. '/home/xeho91/Projects/terminal-nerds/configs/node_modules/.pnpm/local-pkg@0.4.2/node_modules/local-pkg/index.mjs' implicitly has an 'any' type.
> Try `npm i --save-dev @types/local-pkg` if it exists or add a new declaration (.d.ts) file containing `declare module 'local-pkg';`

My project has `tsconfig.json` with the following field set to:

```json
// tsconfig.json
{
  "compilerOptions": {
    "moduleResolution": "NodeNext"
  }
}
```

Of course, when using `"moduleResolution": "Node"`, there's no problem, but I can't change this field for some reasons.

---

So, along with this PR, I am adding a very simple fix to add `types` to the `exports` field object in [./package.json](./package.json) file.
I have tested it by manually editing the `package.json` file inside `./node_modules/local-pkg/package.json` inside my project directory. The warning is gone, and the types works. :man_shrugging:

### Linked Issues

None.

### Additional context

[More information about this from the TypeScript blog - `v4.7`](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-rc/#package-json-exports-imports-and-self-referencing)
