### PR TITLE
feat: `isPackageExists` support version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ import {
 } from 'local-pkg'
 
 isPackageExists('local-pkg') // true
+
+isPackageExists('local-pkg', {
+  version: '> 0.5.1'
+}) // true
+
+isPackageExists('local-pkg', {
+  version: '0.0.0 || 0.1.1'
+}) // false
+
 isPackageExists('foo') // false
 
 await getPackageInfo('local-pkg')

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "dependencies": {
     "mlly": "^1.4.2",
-    "pkg-types": "^1.0.3"
+    "pkg-types": "^1.0.3",
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^1.0.0-beta.18",
@@ -53,6 +54,7 @@
     "@antfu/utils": "^0.7.6",
     "@types/chai": "^4.3.6",
     "@types/node": "^20.8.0",
+    "@types/semver": "^7.5.3",
     "bumpp": "^9.2.0",
     "chai": "^4.3.10",
     "eslint": "^8.50.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   pkg-types:
     specifier: ^1.0.3
     version: 1.0.3
+  semver:
+    specifier: ^7.5.4
+    version: 7.5.4
 
 devDependencies:
   '@antfu/eslint-config':
@@ -28,6 +31,9 @@ devDependencies:
   '@types/node':
     specifier: ^20.8.0
     version: 20.8.0
+  '@types/semver':
+    specifier: ^7.5.3
+    version: 7.5.3
   bumpp:
     specifier: ^9.2.0
     version: 9.2.0
@@ -2604,7 +2610,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: true
 
   /magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
@@ -3129,7 +3134,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3621,7 +3625,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
 
   /yaml-eslint-parser@1.2.2:
     resolution: {integrity: sha512-pEwzfsKbTrB8G3xc/sN7aw1v6A6c/pKxLAkjclnAyo5g5qOh6eL9WGu0o3cSDQZKrTNk4KL4lQSwZW+nBkANEg==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import process from 'node:process'
 import { interopDefault, resolvePathSync } from 'mlly'
 import type { PackageJson } from 'pkg-types'
 import { findUp } from 'find-up'
+import { satisfies } from 'semver'
 
 export interface PackageInfo {
   name: string
@@ -22,6 +23,13 @@ export interface PackageResolvingOptions {
    * Resolve path as posix or win32
    */
   platform?: 'posix' | 'win32' | 'auto'
+}
+
+export interface PackageExistsOptions extends PackageResolvingOptions {
+  /**
+   * match package version with `semver`
+   */
+  version?: string
 }
 
 function _resolve(path: string, options: PackageResolvingOptions = {}) {
@@ -52,7 +60,13 @@ export async function importModule<T = any>(path: string): Promise<T> {
   return i
 }
 
-export function isPackageExists(name: string, options: PackageResolvingOptions = {}) {
+export function isPackageExists(name: string, options: PackageExistsOptions = {}) {
+  if (options.version) {
+    const info = getPackageInfoSync(name, options)
+    if (!info?.version)
+      return false
+    return satisfies(info.version, options.version)
+  }
   return !!resolvePackage(name, options)
 }
 

--- a/test/cjs.cjs
+++ b/test/cjs.cjs
@@ -9,6 +9,13 @@ async function run() {
   expect(resolveModule('@antfu/utils')).to.contain(join('node_modules', '@antfu', 'utils'))
 
   expect(isPackageExists('unbuild')).to.eq(true)
+  expect(isPackageExists('unbuild', {
+    version: '1.0.0',
+  })).to.eq(false)
+
+  expect(isPackageExists('unbuild', {
+    version: '> 1 || < 3',
+  })).to.eq(true)
   expect(isPackageExists('hi')).to.eq(false)
   expect(isPackageExists('esno')).to.eq(true)
 

--- a/test/esm.mjs
+++ b/test/esm.mjs
@@ -9,6 +9,13 @@ async function run() {
   expect(resolveModule('@antfu/utils')).to.contain(join('node_modules', '@antfu', 'utils'))
 
   expect(isPackageExists('unbuild')).to.eq(true)
+  expect(isPackageExists('unbuild', {
+    version: '1.0.0',
+  })).to.eq(false)
+
+  expect(isPackageExists('unbuild', {
+    version: '> 1 || < 3',
+  })).to.eq(true)
   expect(isPackageExists('hi')).to.eq(false)
   expect(isPackageExists('esno')).to.eq(true)
 

--- a/test/source.test.ts
+++ b/test/source.test.ts
@@ -7,6 +7,15 @@ it('test by source', async () => {
   expect(resolveModule('@antfu/utils')).to.contain(join('node_modules', '@antfu', 'utils'))
 
   expect(isPackageExists('unbuild')).to.eq(true)
+
+  expect(isPackageExists('unbuild', {
+    version: '1.0.0',
+  })).to.eq(false)
+
+  expect(isPackageExists('unbuild', {
+    version: '> 1 || < 3',
+  })).to.eq(true)
+
   expect(isPackageExists('hi')).to.eql(false)
   expect(isPackageExists('esno')).to.eq(true)
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR will add version checking support for `semver` rules to `isPackageExists`.
So that we can use it to achieve something like

```ts
const isVue2 = isPackageExists("vue", {
  version: ">2 || <3"
});

export default {
  extends: [
    isVue2
      ? "plugin:vue/recommended"
      : "plugin:vue/vue3-recommended",
  ]
}
```



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
