### PR TITLE
fix: deprecate `isPackageExists` in favor of `doesPackageExist`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,15 @@ export async function importModule<T = any>(path: string): Promise<T> {
   return i
 }
 
-export function isPackageExists(name: string, options: PackageResolvingOptions = {}) {
+export function doesPackageExist(name: string, options: PackageResolvingOptions = {}) {
   return !!resolvePackage(name, options)
+}
+
+/**
+ * @deprecated Use `doesPackageExist` instead.
+ */
+export function isPackageExists(name: string, options: PackageResolvingOptions = {}) {
+  return doesPackageExist(name, options)
 }
 
 function getPackageJsonPath(name: string, options: PackageResolvingOptions = {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,15 +52,15 @@ export async function importModule<T = any>(path: string): Promise<T> {
   return i
 }
 
-export function doesPackageExist(name: string, options: PackageResolvingOptions = {}) {
+export function isPackageInstalled(name: string, options: PackageResolvingOptions = {}) {
   return !!resolvePackage(name, options)
 }
 
 /**
- * @deprecated Use `doesPackageExist` instead.
+ * @deprecated Use `isPackageInstalled` instead.
  */
 export function isPackageExists(name: string, options: PackageResolvingOptions = {}) {
-  return doesPackageExist(name, options)
+  return isPackageInstalled(name, options)
 }
 
 function getPackageJsonPath(name: string, options: PackageResolvingOptions = {}) {

--- a/test/source.test.ts
+++ b/test/source.test.ts
@@ -1,11 +1,16 @@
 import { join } from 'node:path'
 import { promises as fs } from 'node:fs'
 import { expect, it } from 'vitest'
-import { getPackageInfo, importModule, isPackageExists, loadPackageJSON, resolveModule } from '../src'
+import { doesPackageExist, getPackageInfo, importModule, isPackageExists, loadPackageJSON, resolveModule } from '../src'
 
 it('test by source', async () => {
   expect(resolveModule('@antfu/utils')).to.contain(join('node_modules', '@antfu', 'utils'))
 
+  expect(doesPackageExist('unbuild')).to.eq(true)
+  expect(doesPackageExist('hi')).to.eql(false)
+  expect(doesPackageExist('esno')).to.eq(true)
+
+  // TODO: remove in a major version
   expect(isPackageExists('unbuild')).to.eq(true)
   expect(isPackageExists('hi')).to.eql(false)
   expect(isPackageExists('esno')).to.eq(true)

--- a/test/source.test.ts
+++ b/test/source.test.ts
@@ -1,14 +1,14 @@
 import { join } from 'node:path'
 import { promises as fs } from 'node:fs'
 import { expect, it } from 'vitest'
-import { doesPackageExist, getPackageInfo, importModule, isPackageExists, loadPackageJSON, resolveModule } from '../src'
+import { getPackageInfo, importModule, isPackageExists, isPackageInstalled, loadPackageJSON, resolveModule } from '../src'
 
 it('test by source', async () => {
   expect(resolveModule('@antfu/utils')).to.contain(join('node_modules', '@antfu', 'utils'))
 
-  expect(doesPackageExist('unbuild')).to.eq(true)
-  expect(doesPackageExist('hi')).to.eql(false)
-  expect(doesPackageExist('esno')).to.eq(true)
+  expect(isPackageInstalled('unbuild')).to.eq(true)
+  expect(isPackageInstalled('hi')).to.eql(false)
+  expect(isPackageInstalled('esno')).to.eq(true)
 
   // TODO: remove in a major version
   expect(isPackageExists('unbuild')).to.eq(true)


### PR DESCRIPTION
This pull request deprecates `isPackageExists` in favor of `doesPackageExist`, which is grammatically correct. I suggest removing `isPackageExists` in a major version later, but in the meantime, it will simply call `doesPackageExist` under the hood.